### PR TITLE
minor bug fix, remove moment dependency, remove callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ var params = {
   privateKeyPath: '/path/to/private/key',      // Optional. Use as an alternative to privateKeyString.
   expireTime: '<epoch time when you wish the link to expire>'
 }
-cf.getSignedUrl('http://example.com/path/to/s3/object', params, function(err, url) {
-  console.log('Signed URL: ' + url)
-})
+var signedUrl = cf.getSignedUrl('http://example.com/path/to/s3/object', params);
+console.log('Signed URL: ' + signedUrl);
 ```

--- a/lib/cloudfront-util.js
+++ b/lib/cloudfront-util.js
@@ -1,12 +1,11 @@
 
 var crypto = require('crypto')
   , fs = require('fs')
-  , util = require('util')
-  , moment = require('moment')
+  , util = require('util');
 
 var CannedPolicy = function(url, expireTime) {
-  this.url = url
-  this.expireTime = expireTime
+  this.url = url;
+  this.expireTime = expireTime;
 
   this.toJson = function() {
     var policy = {
@@ -18,32 +17,32 @@ var CannedPolicy = function(url, expireTime) {
           }
         }
       }]
-    }
+    };
 
-    return JSON.stringify(policy)
+    return JSON.stringify(policy);
   }
 }
 
 // TODO: Add functionality for custom policies.
-exports.getSignedUrl = function(url, params, cb) {
-  var expireTime = params.expireTime || moment().add('seconds', 30).unix()
+exports.getSignedUrl = function(url, params) {
+  var expireTime = params.expireTime || Math.round((new Date().getTime() + 30000)/1000)
     , policy = new CannedPolicy(url, expireTime)
     , sign = crypto.createSign('RSA-SHA1')
-    , privateKeyString = params.privateKeyString
-  sign.update(policy.toJson())
+    , privateKeyString = params.privateKeyString;
+  sign.update(policy.toJson());
 
   // Stringify private key if supplied as a file path.
   if (params.privateKeyPath) {
     var pem = fs.readFileSync(params.privateKeyPath)
-      , privateKeyString = pem.toString('ascii')
+      , privateKeyString = pem.toString('ascii');
   }
 
   var urlParams = [
     'Key-Pair-Id=' + params.keypairId,
     'Signature=' + sign.sign(privateKeyString, 'base64'),
-    'Expires=' + params.expireTime
-  ]
-  var signedUrl = util.format('%s?%s', url, urlParams.join('&'))
+    'Expires=' + expireTime
+  ];
+  var signedUrl = util.format('%s?%s', url, urlParams.join('&'));
 
-  cb(null, signedUrl)
+  return signedUrl;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-cloudfront-sign",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Utility module for signing AWS CloudFront URLs",
   "main": "./lib/cloudfront-util.js",
   "scripts": {},
@@ -19,6 +19,6 @@
     "url": "https://github.com/jasonsims/aws-cloudfront-sign/issues"
   },
   "dependencies": {
-    "moment": "~2.5.1"
+    
   }
 }


### PR DESCRIPTION
There was a minor bug where if you didn't use the expireTime in the params.

The moment library it a bit bloated and one of the nice things about this library is that it is nice and simple, so I've removed the dependence on moment.

finally, I've removed the need to get the signed url from a callback (in getSignedUrl), since the file read is sync there is really no need and it makes the lib easier to use the call, especially for signing lots of urls at once.
