### PR TITLE
Signature has invalid URL characters

### DIFF
--- a/lib/cloudfront-util.js
+++ b/lib/cloudfront-util.js
@@ -9,11 +9,11 @@ var CannedPolicy = function(url, expireTime) {
 
   this.toJson = function() {
     var policy = {
-      Statement:[{
-        Resource: this.url,
-        Condition: {
-          DateLessThan: {
-            'AWS:EpochTime': this.expireTime
+      "Statement":[{
+        "Resource": this.url,
+        "Condition": {
+          "DateLessThan": {
+            "AWS:EpochTime": this.expireTime
           }
         }
       }]
@@ -39,10 +39,11 @@ exports.getSignedUrl = function(url, params) {
       , privateKeyString = pem.toString('ascii');
   }
 
+  var signature = sign.sign(privateKeyString, 'base64');
   var urlParams = [
-    'Key-Pair-Id=' + params.keypairId,
-    'Signature=' + sign.sign(privateKeyString, 'base64'),
-    'Expires=' + expireTime
+    'Expires=' + expireTime,
+    'Signature=' + signature.replace(/\+/g,"-").replace(/=/g,"_").replace(/\//g,"~"),
+    'Key-Pair-Id=' + params.keypairId
   ];
   var signedUrl = util.format('%s?%s', url, urlParams.join('&'));
 


### PR DESCRIPTION
When attempting to use this module I kept getting HTTP 403 Forbidden
errors from AWS.  Looking into it further and comparing it to the
current AWS CloudFront  documentation at
http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
for creating a Signed URL using a Canned Policy I discovered it
neglected to map the three invalid URL characters "+=/" to "-_~".
Therefore I have updated the code to support this and more closely
conform to the AWS  documentation.
