### PR TITLE
Supporting JavaScript dates for expireTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 [mpalmerlee]: https://github.com/mpalmerlee
 [gregt590]: https://github.com/gregt590
 [tbuchok]: https://github.com/tbuchok
+[alexsaves]: https://github.com/alexsaves
+
+## 1.2.0 (2014-12-31)
+* development: [@alexsaves][alexsaves]: Supporting JavaScript dates for expireTime
+* development: [@alexsaves][alexsaves]: Added range and type checking
+* development: [@alexsaves][alexsaves]: Added `getSignedRTMPUrl` for conveniently generating RTMP style urls
 
 ## 1.1.0 (2014-11-26)
 * bugfix: [@gregt590][gregt590]: Normalize AWS signature strings

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var params = {
   keypairId: process.env.PUBLIC_KEY,
   privateKeyString: process.env.PRIVATE_KEY,
   privateKeyPath: '/path/to/private/key',      // Optional. Use as an alternative to privateKeyString.
-  expireTime: new Date(new Date().getTime() + (1000 * 100)) // Now + 100 seconds
+  expireTime: new Date(2016, 0, 1) // January 1, 2016
 }
 var signedUrl = cf.getSignedUrl('http://example.com/path/to/s3/object', params);
 console.log('Signed URL: ' + signedUrl);

--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ var params = {
   keypairId: process.env.PUBLIC_KEY,
   privateKeyString: process.env.PRIVATE_KEY,
   privateKeyPath: '/path/to/private/key',      // Optional. Use as an alternative to privateKeyString.
-  expireTime: '<epoch time when you wish the link to expire>'
+  expireTime: new Date(new Date().getTime() + (1000 * 100)) // Now + 100 seconds
 }
 var signedUrl = cf.getSignedUrl('http://example.com/path/to/s3/object', params);
 console.log('Signed URL: ' + signedUrl);
+
+var signedRTMPUrlObj = cf.getSignedRTMPUrl('xxxxxxx.cloudfront.net', 'path/to/s3/object', params);
+console.log('RTMP Server Path: ' + signedRTMPUrlObj.rtmpServerPath);
+console.log('Signed Stream Name: ' + signedRTMPUrlObj.rtmpStreamName);
 ```

--- a/lib/CannedPolicy.js
+++ b/lib/CannedPolicy.js
@@ -1,4 +1,3 @@
-
 /**
  * `CannedPolicy` constructor.
  *
@@ -6,8 +5,8 @@
  * @param {Number} Epoch time of URL expiration
  */
 function CannedPolicy(url, expireTime) {
-  this.url = url;
-  this.expireTime = expireTime;
+    this.url = url;
+    this.expireTime = expireTime;
 }
 
 /**
@@ -15,19 +14,34 @@ function CannedPolicy(url, expireTime) {
  *
  * @return {String} Serialized policy
  */
-CannedPolicy.prototype.toJSON = function() {
-  var policy = {
-    'Statement':[{
-      'Resource': this.url,
-      'Condition': {
-        'DateLessThan': {
-          'AWS:EpochTime': this.expireTime
-        }
-      }
-    }]
-  };
+CannedPolicy.prototype.toJSON = function () {
+    if (this._validate())
+        var policy = {
+            'Statement': [{
+                'Resource': this.url,
+                'Condition': {
+                    'DateLessThan': {
+                        'AWS:EpochTime': Math.round(this.expireTime.getTime() / 1000)
+                    }
+                }
+            }]
+        };
 
-  return JSON.stringify(policy);
+    return JSON.stringify(policy);
+};
+
+/**
+ * Check for common mistakes with types
+ * @private
+ */
+CannedPolicy.prototype._validate = function () {
+    if (typeof this.expireTime == 'undefined' || this.expireTime instanceof Date == false)
+        throw new Error("expireTime must be a JavaScript Date!");
+    if (this.expireTime.getTime() / 1000 > 2147483647)
+        throw new Error("expireTime must be less than January 19, 2038 03:14:08 GMT due to the limits of UNIX time.");
+    if (this.expireTime <= new Date())
+        throw new Error("expireTime is below the current time.");
+    return true;
 };
 
 

--- a/lib/CannedPolicy.js
+++ b/lib/CannedPolicy.js
@@ -5,8 +5,8 @@
  * @param {Number} Epoch time of URL expiration
  */
 function CannedPolicy(url, expireTime) {
-    this.url = url;
-    this.expireTime = expireTime;
+  this.url = url;
+  this.expireTime = expireTime;
 }
 
 /**
@@ -15,21 +15,21 @@ function CannedPolicy(url, expireTime) {
  * @return {String} Serialized policy
  */
 CannedPolicy.prototype.toJSON = function () {
-    if (this._validate()) {
-        var policy = {
-            'Statement': [{
-                'Resource': this.url,
-                'Condition': {
-                    'DateLessThan': {
-                        'AWS:EpochTime': Math.round(
-                            this.expireTime.getTime() / 1000
-                        )
-                    }
-                }
-            }]
-        };
-    }
-    return JSON.stringify(policy);
+  if (this._validate()) {
+    var policy = {
+      'Statement': [{
+        'Resource': this.url,
+        'Condition': {
+          'DateLessThan': {
+            'AWS:EpochTime': Math.round(
+              this.expireTime.getTime() / 1000
+            )
+          }
+        }
+      }]
+    };
+  }
+  return JSON.stringify(policy);
 };
 
 /**
@@ -37,33 +37,33 @@ CannedPolicy.prototype.toJSON = function () {
  * @private
  */
 CannedPolicy.prototype._validate = function () {
-    if (typeof this.expireTime === 'undefined') {
-        throw new Error(
-            'expireTime must be a JavaScript Date or a Number.'
-        );
-    }
+  if (typeof this.expireTime === 'undefined') {
+    throw new Error(
+      'expireTime must be a JavaScript Date or a Number.'
+    );
+  }
 
-    // Enforce a common type
-    if (typeof(this.expireTime) === 'number') {
-        this.expireTime = new Date(this.expireTime * 1000);
-    }
-    if (typeof(this.expireTime) === 'string') {
-        this.expireTime = new Date(parseInt(this.expireTime) * 1000);
-    }
+  // Enforce a common type
+  if (typeof(this.expireTime) === 'number') {
+    this.expireTime = new Date(this.expireTime * 1000);
+  }
+  if (typeof(this.expireTime) === 'string') {
+    this.expireTime = new Date(parseInt(this.expireTime) * 1000);
+  }
 
-    if (this.expireTime.getTime() / 1000 > 2147483647) {
-        throw new Error(
-            'expireTime must be less than January 19, 2038 03:14:08 GMT ' +
-            'due to the limits of UNIX time.'
-        );
-    }
-    if (this.expireTime <= new Date()) {
-        throw new Error(
-            'expireTime is below the current time.'
-        );
-    }
+  if (this.expireTime.getTime() / 1000 > 2147483647) {
+    throw new Error(
+      'expireTime must be less than January 19, 2038 03:14:08 GMT ' +
+      'due to the limits of UNIX time.'
+    );
+  }
+  if (this.expireTime <= new Date()) {
+    throw new Error(
+      'expireTime is below the current time.'
+    );
+  }
 
-    return true;
+  return true;
 };
 
 

--- a/lib/CannedPolicy.js
+++ b/lib/CannedPolicy.js
@@ -15,18 +15,20 @@ function CannedPolicy(url, expireTime) {
  * @return {String} Serialized policy
  */
 CannedPolicy.prototype.toJSON = function () {
-    if (this._validate())
+    if (this._validate()) {
         var policy = {
             'Statement': [{
                 'Resource': this.url,
                 'Condition': {
                     'DateLessThan': {
-                        'AWS:EpochTime': Math.round(this.expireTime.getTime() / 1000)
+                        'AWS:EpochTime': Math.round(
+                            this.expireTime.getTime() / 1000
+                        )
                     }
                 }
             }]
         };
-
+    }
     return JSON.stringify(policy);
 };
 
@@ -35,12 +37,32 @@ CannedPolicy.prototype.toJSON = function () {
  * @private
  */
 CannedPolicy.prototype._validate = function () {
-    if (typeof this.expireTime == 'undefined' || this.expireTime instanceof Date == false)
-        throw new Error("expireTime must be a JavaScript Date!");
-    if (this.expireTime.getTime() / 1000 > 2147483647)
-        throw new Error("expireTime must be less than January 19, 2038 03:14:08 GMT due to the limits of UNIX time.");
-    if (this.expireTime <= new Date())
-        throw new Error("expireTime is below the current time.");
+    if (typeof this.expireTime === 'undefined') {
+        throw new Error(
+            'expireTime must be a JavaScript Date or a Number.'
+        );
+    }
+
+    // Enforce a common type
+    if (typeof(this.expireTime) === 'number') {
+        this.expireTime = new Date(this.expireTime * 1000);
+    }
+    if (typeof(this.expireTime) === 'string') {
+        this.expireTime = new Date(parseInt(this.expireTime) * 1000);
+    }
+
+    if (this.expireTime.getTime() / 1000 > 2147483647) {
+        throw new Error(
+            'expireTime must be less than January 19, 2038 03:14:08 GMT ' +
+            'due to the limits of UNIX time.'
+        );
+    }
+    if (this.expireTime <= new Date()) {
+        throw new Error(
+            'expireTime is below the current time.'
+        );
+    }
+
     return true;
 };
 

--- a/lib/cloudfront-util.js
+++ b/lib/cloudfront-util.js
@@ -1,4 +1,3 @@
-
 var crypto = require('crypto');
 var fs = require('fs');
 var util = require('util');
@@ -15,8 +14,8 @@ function getSignedUrl(url, params) {
   // If an expiration time isn't set, default to 30 seconds.
   var defaultExpireTime = new Date(new Date().getTime() + 30000);
   var expireTime = typeof params.expireTime !== 'undefined' ?
-      params.expireTime :
-      defaultExpireTime;
+    params.expireTime :
+    defaultExpireTime;
   var policy = new CannedPolicy(url, expireTime);
   var sign = crypto.createSign('RSA-SHA1');
   var privateKeyString = params.privateKeyString;
@@ -54,15 +53,15 @@ function getSignedRTMPUrl(domainname, s3key, params) {
 
   if (!domainname || domainname.indexOf('/') > -1) {
     throw new Error(
-        'Supplied domain name doesn\'t look right. ' +
-        'Example: \'xxxxxxxx.cloudfront.net\'. Omit \'http\' and any paths.'
+      'Supplied domain name doesn\'t look right. ' +
+      'Example: \'xxxxxxxx.cloudfront.net\'. Omit \'http\' and any paths.'
     );
   }
 
   if (!s3key || s3key.length === 0 || s3key.charAt(0) === '/') {
     throw new Error(
-        'Supplied s3 key doesn\'t look right. ' +
-        'Example: \'myfolder/bla.mp4\'. Omit preceding slashes or hostnames.'
+      'Supplied s3 key doesn\'t look right. ' +
+      'Example: \'myfolder/bla.mp4\'. Omit preceding slashes or hostnames.'
     );
   }
 
@@ -82,7 +81,7 @@ function getSignedRTMPUrl(domainname, s3key, params) {
  */
 function _normalizeSignature(sig) {
   var badCharMap = {'+': '-', '=': '_', '/': '~'};
-  Object.keys(badCharMap).forEach(function(badChar) {
+  Object.keys(badCharMap).forEach(function (badChar) {
     var re = new RegExp('\\' + badChar, 'g');
     sig = sig.replace(re, badCharMap[badChar]);
   });

--- a/lib/cloudfront-util.js
+++ b/lib/cloudfront-util.js
@@ -13,7 +13,7 @@ var CannedPolicy = require('./CannedPolicy');
  */
 function getSignedUrl(url, params) {
   // If an expiration time isn't set, default to 30 seconds.
-  var defaultExpireTime = Math.round((new Date().getTime() + 30000) / 1000);
+  var defaultExpireTime = new Date(new Date().getTime() + 30000);
   var expireTime = params.expireTime || defaultExpireTime;
   var policy = new CannedPolicy(url, expireTime);
   var sign = crypto.createSign('RSA-SHA1');
@@ -31,13 +31,35 @@ function getSignedUrl(url, params) {
 
   signature = sign.sign(privateKeyString, 'base64');
   urlParams = [
-    'Expires=' + expireTime,
+    'Expires=' + Math.round(expireTime.getTime() / 1000),
     'Signature=' + _normalizeSignature(signature),
     'Key-Pair-Id=' + params.keypairId
   ];
 
   // Return a formatted URL string with signature.
   return util.format('%s?%s', url, urlParams.join('&'));
+}
+
+/**
+ * Build an AWS signed RTMP URL assuming your distribution supports this.
+ *
+ * @param {String} Cloudfront domain
+ * @param {String} S3 key
+ * @param {Object} Signature parameters
+ * @return {Object} Cloudfront server path and stream name with RTMP formatting
+ */
+function getSignedRTMPUrl(domainname, s3key, params) {
+
+  if (!domainname || domainname.indexOf('/') > -1)
+    throw new Error("Supplied domain name doesn't look right. Example: \'xxxxxxxx.cloudfront.net\'. Omit 'http' and any paths.");
+
+  if (!s3key || s3key.length === 0 || s3key.charAt(0) == '/')
+    throw new Error("Supplied s3 key doesn't look right. Example: \'myfolder/bla.mp4\'. Omit preceeding slashes or hostnames.");
+
+  return {
+    rtmpServerPath: 'rtmp://' + domainname + '/cfx/st',
+    rtmpStreamName: getSignedUrl(s3key, params)
+  };
 }
 
 /**
@@ -58,4 +80,5 @@ function _normalizeSignature(sig) {
 }
 
 exports.getSignedUrl = getSignedUrl;
+exports.getSignedRTMPUrl = getSignedRTMPUrl;
 exports._normalizeSignature = _normalizeSignature;

--- a/lib/cloudfront-util.js
+++ b/lib/cloudfront-util.js
@@ -14,7 +14,9 @@ var CannedPolicy = require('./CannedPolicy');
 function getSignedUrl(url, params) {
   // If an expiration time isn't set, default to 30 seconds.
   var defaultExpireTime = new Date(new Date().getTime() + 30000);
-  var expireTime = params.expireTime || defaultExpireTime;
+  var expireTime = typeof params.expireTime !== 'undefined' ?
+      params.expireTime :
+      defaultExpireTime;
   var policy = new CannedPolicy(url, expireTime);
   var sign = crypto.createSign('RSA-SHA1');
   var privateKeyString = params.privateKeyString;
@@ -31,7 +33,7 @@ function getSignedUrl(url, params) {
 
   signature = sign.sign(privateKeyString, 'base64');
   urlParams = [
-    'Expires=' + Math.round(expireTime.getTime() / 1000),
+    'Expires=' + Math.round(policy.expireTime.getTime() / 1000),
     'Signature=' + _normalizeSignature(signature),
     'Key-Pair-Id=' + params.keypairId
   ];
@@ -50,11 +52,19 @@ function getSignedUrl(url, params) {
  */
 function getSignedRTMPUrl(domainname, s3key, params) {
 
-  if (!domainname || domainname.indexOf('/') > -1)
-    throw new Error("Supplied domain name doesn't look right. Example: \'xxxxxxxx.cloudfront.net\'. Omit 'http' and any paths.");
+  if (!domainname || domainname.indexOf('/') > -1) {
+    throw new Error(
+        'Supplied domain name doesn\'t look right. ' +
+        'Example: \'xxxxxxxx.cloudfront.net\'. Omit \'http\' and any paths.'
+    );
+  }
 
-  if (!s3key || s3key.length === 0 || s3key.charAt(0) == '/')
-    throw new Error("Supplied s3 key doesn't look right. Example: \'myfolder/bla.mp4\'. Omit preceeding slashes or hostnames.");
+  if (!s3key || s3key.length === 0 || s3key.charAt(0) === '/') {
+    throw new Error(
+        'Supplied s3 key doesn\'t look right. ' +
+        'Example: \'myfolder/bla.mp4\'. Omit preceding slashes or hostnames.'
+    );
+  }
 
   return {
     rtmpServerPath: 'rtmp://' + domainname + '/cfx/st',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-cloudfront-sign",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Utility module for signing AWS CloudFront URLs",
   "author": "Jason Sims <sims.jrobert@gmail.com>",
   "contributors": [

--- a/test/lib/cloud-front-util.test.js
+++ b/test/lib/cloud-front-util.test.js
@@ -10,7 +10,7 @@ var DEFAULT_PARAMS = {
     path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii')
 };
 
-test('canned policy', function(t) {
+test('canned policy', function (t) {
   var now = new Date();
   var result = url.parse(cf.getSignedUrl('http://foo.com', DEFAULT_PARAMS));
   var expireDiff;
@@ -27,13 +27,13 @@ test('canned policy', function(t) {
   t.end();
 });
 
-test('signature', function(t) {
+test('signature', function (t) {
   var result = parseUrl(cf.getSignedUrl('http://foo.com', DEFAULT_PARAMS));
   t.ok(result.query.hasOwnProperty('Signature'), 'it should be created');
   t.end();
 });
 
-test('signature#_normalizeSignature', function(t) {
+test('signature#_normalizeSignature', function (t) {
   var illegalChars = ['+', '=', '/'];
   var arg = illegalChars.join('');
   var sig = cf._normalizeSignature(arg);
@@ -42,11 +42,11 @@ test('signature#_normalizeSignature', function(t) {
   t.end();
 });
 
-test('canned policy types', function(t) {
+test('canned policy types', function (t) {
   var result1 = url.parse(cf.getSignedUrl('http://foo.com', {
     keypairId: 'ABC123',
     privateKeyString: fs.readFileSync(
-        path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
+      path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
     expireTime: ((new Date(2033, 1, 1)).getTime() / 1000).toString()
   }));
   t.ok(result1.path.indexOf('=1990857600') > -1, 'it should support legacy unix time strings as expire times.');
@@ -54,7 +54,7 @@ test('canned policy types', function(t) {
   var result2 = url.parse(cf.getSignedUrl('http://foo.com', {
     keypairId: 'ABC123',
     privateKeyString: fs.readFileSync(
-        path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
+      path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
     expireTime: ((new Date(2033, 1, 1)).getTime() / 1000)
   }));
   t.ok(result2.path.indexOf('=1990857600') > -1, 'it should support integer time expire times.');
@@ -62,7 +62,7 @@ test('canned policy types', function(t) {
   var result3 = url.parse(cf.getSignedUrl('http://foo.com', {
     keypairId: 'ABC123',
     privateKeyString: fs.readFileSync(
-        path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
+      path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
     expireTime: new Date(2033, 1, 1)
   }));
   t.ok(result3.path.indexOf('=1990857600') > -1, 'it should support Date objects as expire times.');
@@ -73,10 +73,11 @@ test('canned policy types', function(t) {
     result4 = url.parse(cf.getSignedUrl('http://foo.com', {
       keypairId: 'ABC123',
       privateKeyString: fs.readFileSync(
-          path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
+        path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
       expireTime: new Date(1000, 1, 1)
     }));
-  } catch(e) {}
+  } catch (e) {
+  }
   t.ok(typeof(result4) == 'undefined', 'it should alert the developer about urls that have already expired.');
 
   var result5;
@@ -85,20 +86,21 @@ test('canned policy types', function(t) {
     result5 = url.parse(cf.getSignedUrl('http://foo.com', {
       keypairId: 'ABC123',
       privateKeyString: fs.readFileSync(
-          path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
+        path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
       expireTime: new Date(3000, 1, 1)
     }));
-  } catch(e) {}
+  } catch (e) {
+  }
   t.ok(typeof(result5) == 'undefined', 'it should alert the developer about invalid unix dates that AWS will not accept.');
 
   t.end();
 });
 
-test('RTMP URL Objects', function(t) {
+test('RTMP URL Objects', function (t) {
   var result1 = cf.getSignedRTMPUrl('xxxxxx.cloudfront.net', 'mykeyfolder/mykey.mp4', {
     keypairId: 'ABC123',
     privateKeyString: fs.readFileSync(
-        path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
+      path.join(process.cwd(), 'test/files/dummy.pem')).toString('ascii'),
     expireTime: new Date(2033, 1, 1)
   });
   t.ok(result1.rtmpServerPath.indexOf('cfx/st') > -1, 'it should return a properly formatted rtmp server path.');


### PR DESCRIPTION
Made some enhancements that I hope will make things a little easier for others. Specifically:

Now supporting JavaScript dates for expireTime
Added range and type checking for unix dates
Added `getSignedRTMPUrl` for conveniently generating RTMP style urls - this was confusing for me. Hope this helps!