### PR TITLE
Added the ability to restrict to an IP mask

### DIFF
--- a/lib/CannedPolicy.js
+++ b/lib/CannedPolicy.js
@@ -3,10 +3,12 @@
  *
  * @param {String} Resource URL
  * @param {Number} Epoch time of URL expiration
+ * @param {String} IP Address/range to allow in this request
  */
-function CannedPolicy(url, expireTime) {
+function CannedPolicy(url, expireTime, ipRange) {
   this.url = url;
   this.expireTime = Math.round(expireTime/ 1000) || undefined;
+  this.ipRange = ipRange;
 }
 
 /**
@@ -28,6 +30,12 @@ CannedPolicy.prototype.toJSON = function() {
       }
     }]
   };
+
+  if (this.ipRange) {
+    policy.Statement[0].Condition.IpAddress = {
+      'AWS:SourceIp': this.ipRange
+    };
+  }
 
   return JSON.stringify(policy);
 };

--- a/lib/cloudfrontUtil.js
+++ b/lib/cloudfrontUtil.js
@@ -20,7 +20,8 @@ function getSignedUrl(cfUrl, params) {
   // If an expiration time isn't set, default to 30 seconds.
   var defaultExpireTime = Math.round(new Date().getTime() + 30000);
   var expireTime = _getExpireTime(params) || defaultExpireTime;
-  var policy = new CannedPolicy(cfUrl, expireTime);
+  var ipRange = _getIpRange(params);
+  var policy = new CannedPolicy(cfUrl, expireTime, ipRange);
   var sign = crypto.createSign('RSA-SHA1');
   var privateKeyString = params.privateKeyString;
   var parsedUrl;
@@ -133,8 +134,15 @@ function _getExpireTime(opts) {
   throw new Error('Invalid `expireTime` value');
 }
 
+function _getIpRange(opts) {
+  if (!opts.ipRange) { return null;}
+
+  return opts.ipRange;
+}
+
 
 exports.getSignedUrl = getSignedUrl;
 exports.getSignedRTMPUrl = getSignedRTMPUrl;
 exports.normalizeSignature = normalizeSignature;
 exports._getExpireTime = _getExpireTime;
+exports._getIpRange = _getIpRange;

--- a/test/lib/CannedPolicy.test.js
+++ b/test/lib/CannedPolicy.test.js
@@ -49,6 +49,22 @@ describe('CannedPolicy', function() {
       expect(func).to.throw(Error, /.*must be after the current time$/i);
       done();
     });
+    it('should return a canned policy with ip address restriction', function(done) {
+      var expireTimeMs = new Date().getTime() + 10000;
+      var policy = new CannedPolicy('http://t.com', expireTimeMs, "1.2.3.0/24");
+      var result = policy.toJSON();
+      var parsedResult;
+
+      expect(result).to.be.a('string');
+
+      // Parse the stringified result so we can examine it's properties.
+      parsedResult = JSON.parse(result);
+
+      expect(parsedResult).to.have.deep.property(
+        'Statement[0].Condition.IpAddress.AWS:SourceIp', "1.2.3.0/24");
+
+      done();
+    });
     it('should return the canned policy as stringified JSON', function(done) {
       var expireTimeMs = new Date().getTime() + 10000;
       var expireTimeSecs = Math.round(expireTimeMs / 1000);


### PR DESCRIPTION
We needed the ability to tie a signed cloudfront URL to a specific IP CIDR mask. Your library is very useful, and hoped you'd accept our contribution back. Thanks.