### PR TITLE
Added in error handling for an invalid formatted private key string. …

### DIFF
--- a/lib/cloudfrontUtil.js
+++ b/lib/cloudfrontUtil.js
@@ -214,6 +214,11 @@ function _getPrivateKey(params) {
     privateKeyString = pem.toString('ascii');
   }
 
+  var lineBreakExists = /\r|\n/.exec(privateKeyString);
+  if (!lineBreakExists) {
+      throw new Error('Invalid private key string, must include line breaks');
+  }
+
   return privateKeyString;
 }
 

--- a/lib/cloudfrontUtil.js
+++ b/lib/cloudfrontUtil.js
@@ -214,7 +214,7 @@ function _getPrivateKey(params) {
     privateKeyString = pem.toString('ascii');
   }
 
-  var newLinePattern = '/\r|\n/';
+  var newLinePattern = /\r|\n/;
   var lineBreakExists = newLinePattern.test(privateKeyString);
   if (!lineBreakExists) {
       throw new Error('Invalid private key string, must include line breaks');

--- a/lib/cloudfrontUtil.js
+++ b/lib/cloudfrontUtil.js
@@ -214,7 +214,8 @@ function _getPrivateKey(params) {
     privateKeyString = pem.toString('ascii');
   }
 
-  var lineBreakExists = /\r|\n/.exec(privateKeyString);
+  var newLinePattern = '/\r|\n/';
+  var lineBreakExists = newLinePattern.test(privateKeyString);
   if (!lineBreakExists) {
       throw new Error('Invalid private key string, must include line breaks');
   }

--- a/test/lib/cloudfrontUtil.test.js
+++ b/test/lib/cloudfrontUtil.test.js
@@ -107,6 +107,15 @@ describe('CloudfrontUtil', function() {
       done();
     });
 
+    it('should fail to accept singe line private key as string', function(done) {
+      var testExpireTime = moment().add(1, 'day').unix() * 1000;
+      var params = _.extend({}, defaultParams);
+      params.privateKeyString = "this_is_a_test_..._a_single_line_string";
+
+      expect(CloudfrontUtil.getSignedUrl.bind('http://foo.com', params)).to.throw(Error);
+      done();
+    });
+
     it('should accept private key as filepath', function(done) {
       var testExpireTime = moment().add(1, 'day').unix() * 1000;
       var params = _.extend({}, defaultParams, {


### PR DESCRIPTION
…The crypto error handling for this error isnt intuitive, and it should be caught before being passed along to crypto