### PR TITLE
Increased default expire time from 30 seconds to 30 minutes as discussed in #29.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ npm install aws-cloudfront-sign
 * `@return {Object} cookies` - Signed AWS cookies
 
 ### Options
-* `expireTime` (**Optional** - Default: 30s) - The time when the URL should
-   expire. Accepted values are
-   * number - Time in milliseconds (`new Date().getTime() + 30000`)
+* `expireTime` (**Optional** - Default: 1800 sec == 30 min) - The time when the URL should expire. Accepted values are
+   * number - Time in milliseconds (`new Date().getTime() + 1800000`)
    * moment - Valid [momentjs][moment_docs] object (`moment().add(1, 'day')`)
    * Date - Javascript Date object (`new Date(2016, 0, 1)`)
 * `ipRange` (**Optional**) - IP address range allowed to make GET requests
@@ -85,6 +84,7 @@ npm install aws-cloudfront-sign
 
 ## Examples
 ### Creating a signed URL
+By default the URL will expire after half an hour.
 ```js
 var cf = require('aws-cloudfront-sign')
 var options = {keypairId: 'APKAJM2FEVTI7BNPCY4A', privateKeyPath: '/foo/bar'}

--- a/lib/cloudfrontUtil.js
+++ b/lib/cloudfrontUtil.js
@@ -118,7 +118,7 @@ function normalizeBase64(str) {
  * http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
  *
  * @deprecated
- * @param {String}: Base64 encoded signature string
+
  */
 function normalizeSignature(sig) {
   console.log(
@@ -137,8 +137,8 @@ function normalizeSignature(sig) {
  * @returns {Object} AWS policy object
  */
 function _createPolicy(cfUrl, expireTime, ipRange) {
-  // If an expiration time isn't set, default to 30 seconds.
-  var defaultExpireTime = Math.round(Date.now() + 30000);
+  // If an expiration time isn't set, default to 30 minutes.
+  var defaultExpireTime = Math.round(Date.now() + 1800000);
   expireTime = expireTime || defaultExpireTime;
 
   return new CannedPolicy(cfUrl, expireTime, ipRange);

--- a/test/lib/cloudfrontUtil.test.js
+++ b/test/lib/cloudfrontUtil.test.js
@@ -132,12 +132,12 @@ describe('CloudfrontUtil', function() {
       done();
     });
 
-    it('should default `expireTime` to 30 seconds', function(done) {
+    it('should default `expireTime` to 30 minutes (1800 seconds)', function(done) {
       var params = _.extend({}, defaultParams);
       var result = CloudfrontUtil.getSignedUrl('http://foo.com', params);
       var parsedResult = url.parse(result, true);
 
-      expect(parsedResult.query.Expires).to.equal('30');
+      expect(parsedResult.query.Expires).to.equal('1800');
       done();
     });
 


### PR DESCRIPTION
Increased default expire time from 30 seconds to 30 minutes to prevent `Access Denied` errors due to expired links from possible server clockdrift.