### PR TITLE
Updated vulnerable packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "url": "https://github.com/jasonsims/aws-cloudfront-sign/issues"
   },
   "dependencies": {
-    "lodash": "^3.6.0"
+    "lodash": "^4.17.10"
   },
   "tonicExampleFilename": "./examples/signedURL.js",
   "devDependencies": {
     "chai": "^2.2.0",
-    "mocha": "^2.2.1",
+    "mocha": "^5.2.0",
     "moment": "^2.9.0",
     "sinon": "^1.14.1"
   }


### PR DESCRIPTION
Lodash and mocha threw warnings when running nsp check or npm audit. This commit updates those package to the lastest version.