### PR TITLE
Use more secure version of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/jasonsims/aws-cloudfront-sign/issues"
   },
   "dependencies": {
-    "lodash": "^3.6.0"
+    "lodash": "^4.17.15"
   },
   "tonicExampleFilename": "./examples/signedURL.js",
   "devDependencies": {


### PR DESCRIPTION
Current version of lodash in package.json has following vulnerabilities:
* https://nodesecurity.io/advisories/782
* https://nodesecurity.io/advisories/1065
* https://nodesecurity.io/advisories/577