### PR TITLE
add suport for whatwg url policy

### DIFF
--- a/lib/cloudfrontUtil.js
+++ b/lib/cloudfrontUtil.js
@@ -10,13 +10,45 @@ var _ = require('lodash');
 var CannedPolicy = require('./CannedPolicy');
 
 /**
- * Build an AWS signed URL.
+ * Build an AWS signed URL using WHATWG URL policy
  *
- * @param {String} CloudFront resource URL
- * @param {Object} Signature parameters
+ * @param {Object} params Signature parameters
+ * @return {String} Signed CloudFront URL
+ * @throws {TypeError}
+ */
+function getSignedWhatwgUrl(params) {
+  if (!params.url || !params.pathname) {
+    throw new TypeError('Invalid options; url and pathname are required.');
+  }
+
+  var cfUrl = params.url + params.pathname;
+
+  var privateKey = _getPrivateKey(params);
+  var policy = _createPolicy(
+      cfUrl, _getExpireTime(params), _getIpRange(params));
+  var signature = _createPolicySignature(policy, privateKey);
+  var policyStr = new Buffer(policy.toJSON()).toString('base64');
+
+  var whatwgUrl = new url.URL(params.pathname, params.url);
+  whatwgUrl.searchParams.append('Expires', policy.expireTime);
+  whatwgUrl.searchParams.append('Policy', normalizeBase64(policyStr));
+  whatwgUrl.searchParams.append('Signature', normalizeBase64(signature));
+  whatwgUrl.searchParams.append('Key-Pair-Id', params.keypairId);
+  return whatwgUrl.toString();
+}
+
+/**
+ * Build an AWS signed URL using the legacy nodejs URL object.
+ *
+ * @param {String} [cfUrl] CloudFront resource URL - optional, if omitted, params.url and params.pathname are required
+ * @param {Object} params Signature parameters
  * @return {String} Signed CloudFront URL
  */
 function getSignedUrl(cfUrl, params) {
+  if (arguments.length === 1) {
+    return getSignedWhatwgUrl(cfUrl);
+  }
+
   var privateKey = _getPrivateKey(params);
   var policy = _createPolicy(
     cfUrl, _getExpireTime(params), _getIpRange(params));
@@ -207,6 +239,7 @@ function _getPrivateKey(params) {
 
 exports.getSignedCookies = getSignedCookies;
 exports.getSignedUrl = getSignedUrl;
+exports.getSignedWhatwgUrl = getSignedWhatwgUrl;
 exports.getSignedRTMPUrl = getSignedRTMPUrl;
 exports.normalizeSignature = normalizeSignature;
 exports.normalizeBase64 = normalizeBase64;


### PR DESCRIPTION
This library is using the Legacy URL API for NodeJS.  Because of this, some characters that no longer need to be encoded in the pathname are being encoded.  This results in 404 or 403 responses from CloudFront when using S3 as an origin.

[https://nodejs.org/api/url.html#url_legacy_url_api](https://nodejs.org/api/url.html#url_legacy_url_api)
The legacy urlObject (require('url').Url) is created and returned by the url.parse() function. 

[https://nodejs.org/api/url.html#url_percent_encoding_in_urls](https://nodejs.org/api/url.html#url_percent_encoding_in_urls)
Percent-Encoding in URLs#
URLs are permitted to only contain a certain range of characters. Any character falling outside of that range must be encoded. How such characters are encoded, and which characters to encode depends entirely on where the character is located within the structure of the URL.

(https://nodejs.org/api/url.html#url_legacy_api)[https://nodejs.org/api/url.html#url_legacy_api]
Legacy API#
Within the Legacy API, spaces (' ') and the following characters will be automatically escaped in the properties of URL objects:

< > " ` \r \n \t { } | \ ^ '
For example, the ASCII space character (' ') is encoded as %20. The ASCII forward slash (/) character is encoded as %3C.

In my case, an apostrophe was being encoded as %27 and causing a 403.

This PR offers a new method signature for getSignedUrl:

`cf.getSignedUrl({ url, pathname, ... })`

where url is the base url `https://cdn.mydomain.com/` and pathname is the absolute pathname on the base url, following the NodeJS URL constructor arguments `const myURL = new URL('/foo', 'https://example.org/');`

This PR also exposes getWhatwgUrl, so you can call it directly:

`cf.getWhatwgUrl({ url, pathname, ... })`