### PR TITLE
Update package.json version to match release 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-cloudfront-sign",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Utility module for signing AWS CloudFront URLs",
   "author": "Jason Sims <sims.jrobert@gmail.com>",
   "contributors": [


### PR DESCRIPTION
Addresses issue #64 and issue #65 . It looks like the package.json file was not updated to match the last release number. This is causing this library to not publish to NPM.

@jasonsims FYI.