### PR TITLE
fix: update lodash version to cover it's vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/jasonsims/aws-cloudfront-sign/issues"
   },
   "dependencies": {
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.21"
   },
   "tonicExampleFilename": "./examples/signedURL.js",
   "devDependencies": {


### PR DESCRIPTION
Update lodash dependency from 4.17.19 to 4.17.21
Covering library vulnerabilities patched in 4.17.21 such as:
Command Injection: https://github.com/advisories/GHSA-35jh-r3h4-6jhm
Regular Expression Denial of Service (ReDoS): https://github.com/advisories/GHSA-29mw-wpgm-hmr9
